### PR TITLE
support raknet version 11

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -35,6 +35,7 @@ pub struct RaknetSocket {
     incomming_notifier: Arc<Notify>,
     sender: Sender<(Vec<u8>, SocketAddr, bool, u8)>,
     drop_notifier: Arc<Notify>,
+    raknet_version :u8,
 }
 
 impl RaknetSocket {
@@ -47,6 +48,7 @@ impl RaknetSocket {
         receiver: Receiver<Vec<u8>>,
         mtu: u16,
         collecter: Arc<Mutex<Sender<SocketAddr>>>,
+        raknet_version :u8,
     ) -> Self {
         let (user_data_sender, user_data_receiver) = channel::<Vec<u8>>(100);
         let (sender_sender, sender_receiver) = channel::<(Vec<u8>, SocketAddr, bool, u8)>(10);
@@ -64,6 +66,7 @@ impl RaknetSocket {
             incomming_notifier: Arc::new(Notify::new()),
             sender: sender_sender,
             drop_notifier: Arc::new(Notify::new()),
+            raknet_version : raknet_version,
         };
         ret.start_receiver(s, receiver, user_data_sender);
         ret.start_tick(s, Some(collecter));
@@ -186,7 +189,12 @@ impl RaknetSocket {
     ///    //do something
     /// }
     /// ```
-    pub async fn connect(addr: &SocketAddr) -> Result<Self> {
+    
+    pub async fn connect(addr : &SocketAddr) -> Result<Self>{
+        Self::connect_with_version(addr,RAKNET_PROTOCOL_VERSION).await
+    }
+    
+    pub async fn connect_with_version(addr : &SocketAddr, raknet_version :u8) -> Result<Self>{
         let guid: u64 = rand::random();
 
         let s = match UdpSocket::bind("0.0.0.0:0").await {
@@ -196,7 +204,7 @@ impl RaknetSocket {
 
         let packet = OpenConnectionRequest1 {
             magic: true,
-            protocol_version: RAKNET_PROTOCOL_VERSION,
+            protocol_version: raknet_version,
             mtu_size: RAKNET_CLIENT_MTU,
         };
 
@@ -394,6 +402,7 @@ impl RaknetSocket {
             incomming_notifier: Arc::new(Notify::new()),
             sender: sender_sender,
             drop_notifier: Arc::new(Notify::new()),
+            raknet_version : raknet_version,
         };
 
         ret.start_receiver(&s, receiver, user_data_sender);
@@ -875,6 +884,11 @@ impl RaknetSocket {
     /// ```
     pub fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.local_addr)
+    }
+    
+    /// return the raknet version used by this connection.
+    pub fn raknet_version(&self) -> Result<u8>{
+        Ok(self.raknet_version)
     }
 
     /// Set the packet loss rate and use it for testing

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
-pub const RAKNET_PROTOCOL_VERSION: u8 = 10;
+pub const RAKNET_PROTOCOL_VERSION : u8 = 10;
+pub const RAKNET_PROTOCOL_VERSION_LIST : [u8;2] = [10,11];
 //the MTU is minecraft bedrock 1.18.2 give me
 pub const RAKNET_CLIENT_MTU: u16 = 1400;
 


### PR DESCRIPTION
1. 使RaknetSocket类保存当前链接使用的raknet version。
2. 使RaknetListener::listen与RaknetSocket::connect适配raknet version。