### PR TITLE
Make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 
 mod arq;
 mod datatype;
-mod error;
+pub mod error;
 mod fragment;
 mod log;
 mod packet;


### PR DESCRIPTION
Allows errors to be used in external crates.