### PR TITLE
Allow a listener's GUID to be read

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -504,6 +504,11 @@ impl RaknetListener {
         }
     }
 
+    /// Get the GUID, a random number that uniquely identifies the listener instance.
+    pub fn get_guid(&self) -> u64 {
+        self.guid
+    }
+
     /// Set the current motd, this motd will be provided to the client in the unconnected pong.
     ///
     /// Call this method must be after calling RaknetListener::listen()


### PR DESCRIPTION
This allows `Listener::set_full_motd` to be used without having to generate our own GUID.