### PR TITLE
Fix typo in RaknetError and set motd methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 pub enum RaknetError {
     SetRaknetRawSocketError,
     NotListen,
-    BindAdressError,
+    BindAddressError,
     ConnectionClosed,
     NotSupportVersion,
     IncorrectReply,
@@ -13,6 +13,7 @@ pub enum RaknetError {
     ReadPacketBufferError,
     PacketSizeExceedMTU,
     PacketHeaderError,
+    SetMotdError,
 }
 
 pub type Result<T> = std::result::Result<T, RaknetError>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -530,12 +530,7 @@ impl RaknetListener {
     /// # Example
     /// ```ignore
     /// let mut listener = RaknetListener::bind("127.0.0.1:19132".parse().unwrap()).await.unwrap();
-    /// match listener.set_full_motd(String::from("motd")).await {
-    ///     Ok(_) => (),
-    ///     Err(_) => {
-    ///         println!("Failed to update full motd!");
-    ///     },
-    /// };
+    /// listener.set_motd("Another Minecraft Server" , 999999 , "486" , "1.18.11", "Survival" , 19132).await.unwrap();
     /// ```
     pub async fn set_motd(
         &mut self,
@@ -621,7 +616,7 @@ impl RaknetListener {
     /// # Example
     /// ```ignore
     /// let mut listener = RaknetListener::bind("127.0.0.1:19132".parse().unwrap()).await.unwrap();
-    /// listener.set_motd("Another Minecraft Server" , 999999 , "486" , "1.18.11", "Survival" , 19132).await.unwrap();
+    /// listener.set_full_motd(String::from("motd")).await.unwrap();
     /// ```
     pub async fn set_full_motd(&mut self, motd: String) -> Result<()>{
         match self.motd_sender.send(motd.clone()).await {

--- a/src/server.rs
+++ b/src/server.rs
@@ -525,7 +525,7 @@ impl RaknetListener {
     ///
     /// Call this method must be after calling RaknetListener::listen()
     ///
-    /// Returns a result with RaknetError::SetMotdError if failed to send new motd to motd_receiver (so it doesn't update) or with () if everything went smooth
+    /// Returns a result with RaknetError::SetMotdError if failed to send new motd to motd_receiver (so it doesn't update) or with () if everything went smooth.
     /// 
     /// # Example
     /// ```ignore
@@ -616,7 +616,7 @@ impl RaknetListener {
 
     /// Set full motd string.
     /// 
-    /// Returns a result with RaknetError::SetMotdError if failed to send new motd to motd_receiver (so it doesn't update) or with () if everything went smooth
+    /// Returns a result with RaknetError::SetMotdError if failed to send new motd to motd_receiver (so it doesn't update) or with () if everything went smooth.
     /// 
     /// # Example
     /// ```ignore

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -199,7 +199,7 @@ impl RaknetSocket {
 
         let s = match UdpSocket::bind("0.0.0.0:0").await {
             Ok(p) => p,
-            Err(_) => return Err(RaknetError::BindAdressError),
+            Err(_) => return Err(RaknetError::BindAddressError),
         };
 
         let packet = OpenConnectionRequest1 {
@@ -741,7 +741,7 @@ impl RaknetSocket {
     pub async fn ping(addr: &SocketAddr) -> Result<(i64, String)> {
         let s = match UdpSocket::bind("0.0.0.0:0").await {
             Ok(p) => p,
-            Err(_) => return Err(RaknetError::BindAdressError),
+            Err(_) => return Err(RaknetError::BindAddressError),
         };
 
         loop {


### PR DESCRIPTION
## Typo in RaknetError:
I renamed `BindAdressError` to `BindAddressError`

## Set motd methods:
Fix of #19 issue

I created `motd_receiver` and `motd_sender`. Every iteration in `RaknetListener::listen()` it will check if there is message in `motd_receiver`. If there is, server will use updated motd and if not will use last recived.

Also `set_motd()` and `set_full_motd()` methods now will also send message to the `motd_sender` and if it wasn't successful return `RaknetError::SetMotdError`